### PR TITLE
Add endpoint output, pause-idle mode, and optional PR-comment notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,58 @@ When Breakpoint activates, it will output on a regular basis how much time left 
 └───────────────────────────────────────────────────────────────────────────┘
 ```
 
+### Pause with idle-aware timeout
+
+`mode: pause-idle` pauses the workflow until either (a) no SSH session has
+connected within `grace-period`, or (b) a session connected and then all
+sessions have been disconnected for longer than `idle-timeout`. This is useful
+when you want "long enough for a human to attach if they're around, no longer
+than necessary if they're not".
+
+```yaml
+- name: Pause with idle-aware timeout
+  if: failure()
+  uses: namespacelabs/breakpoint-action@v0
+  with:
+    mode: pause-idle
+    grace-period: 5m
+    idle-timeout: 20m
+    authorized-users: jack123, alice321
+```
+
+### Discovering the SSH endpoint outside the runner
+
+The action emits the SSH connection string (`Connect with: ssh -p ... runner@...`)
+to the step log, but GitHub buffers step logs until the step completes — which
+for `pause`-style modes means the endpoint is invisible until the breakpoint
+ends. To make the endpoint observable while the step is still active, the
+action also:
+
+- Sets a step output `endpoint`, e.g. `${{ steps.bp.outputs.endpoint }}`.
+- Emits a Check Run annotation via `::notice::`, visible in the run summary
+  and queryable through the REST API while the run is in progress.
+- Optionally posts a pull-request comment with the endpoint (and removes it on
+  exit). Useful for external CI watchers / AI assistants that follow PR events.
+
+```yaml
+- name: Pause on failure with PR notification
+  if: failure() && github.event_name == 'pull_request'
+  id: bp
+  uses: namespacelabs/breakpoint-action@v0
+  with:
+    mode: pause-idle
+    authorized-users: jack123, alice321
+    comment-on-pr: true
+    github-token: ${{ github.token }}
+    comment-marker: BREAKPOINT_OPEN
+    comment-extra-hint: |
+      Run inside the SSH session:
+      `docker exec -ti $(docker ps --filter name=my-sandbox -q | head -1) bash`
+```
+
+The PR comment uses the configurable `comment-marker` as an HTML comment on
+the first line, so other tooling can grep for it.
+
 ### Run in the background
 
 Breakpoint can also be started in the background to allow connecting at any point during the workflow.
@@ -123,11 +175,41 @@ This action offers inputs that you can use to configure `breakpoint` behavior:
 
   The default value is "30m".
 
-- `mode` - is the mode that breakpoint is started with. Either _pause_ (the default)
-  or _background_. When running in the background, Breakpoint won't block your workflow.
-  The duration input will have no effect when running in the background.
+- `mode` - is the mode that breakpoint is started with. Either _pause_ (the default),
+  _background_ or _pause-idle_. _pause_ blocks until duration is reached or the user
+  resumes. _background_ won't block your workflow (and the duration input is ignored).
+  _pause-idle_ blocks while there are active SSH connections, with a `grace-period`
+  for the first connection and an `idle-timeout` after the last one.
 
   The default value is "pause"
+
+- `grace-period` - (pause-idle only) how long to wait for the first SSH connection
+  before giving up. Accepts Go duration syntax (e.g. `5m`, `30s`).
+
+  The default value is "5m".
+
+- `idle-timeout` - (pause-idle only) how long with zero active SSH connections
+  before the breakpoint exits, after at least one session has connected.
+
+  The default value is "20m".
+
+- `comment-on-pr` - if `true`, post a pull-request comment when the SSH endpoint
+  is detected, and delete it on exit. Requires `github-token` with
+  `pull-requests: write` and a `pull_request` event context.
+
+  The default value is "false".
+
+- `github-token` - token used to post and delete the PR comment. Typically
+  `${{ github.token }}` or a PAT with `pull-requests:write`.
+
+- `comment-marker` - opaque HTML-comment marker placed on the first line of the
+  PR comment. Other tooling (CI watchers, AI assistants) can search the PR
+  comment list for this marker.
+
+  The default value is "BREAKPOINT_OPEN".
+
+- `comment-extra-hint` - optional extra Markdown appended to the PR comment
+  body. Useful for project-specific hints (e.g. how to enter a debug sandbox).
 
 - `authorized-users` - is the comma-separated list of GitHub users that would be
   allowed to SSH into a GitHub Runner. GitHub users would need to have their
@@ -163,3 +245,9 @@ This action offers inputs that you can use to configure `breakpoint` behavior:
 Note, that `authorized-users` and `authorized-keys` used to provided SSH access
 to a GitHub Runner. The action will fail if neither `authorized-users` nor
 `authorized-keys` is provided.
+
+## Outputs
+
+- `endpoint` - the SSH endpoint string emitted by breakpoint
+  (e.g. `ssh -p 40812 runner@rendezvous.namespace.so`), or empty if it was
+  not detected before the step finished.

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,22 @@
 name: 'Add a breakpoint to CI'
 description: 'Pause, debug with SSH and resume GitHub Actions'
-author: 'Namespace Labs'
+author: 'Namespace Labs (fork by Cozystack)'
 branding:
   icon: 'pause-circle'
   color: 'blue'
 inputs:
   mode:
-    description: "One of 'pause' or 'background'. 'pause' will pause your workflow until you tell it to continue (or duration is reached). 'background' will run in the background allowing you to connect at any time during your workflow"
+    description: >
+      One of 'pause', 'background', or 'pause-idle'. 'pause' pauses the workflow
+      until you resume it (or duration is reached). 'background' runs in the
+      background allowing you to connect at any time during your workflow.
+      'pause-idle' (cozystack extension) pauses for an initial grace period to
+      wait for the first SSH connection, then keeps the workflow paused while
+      any SSH session is active and exits after a configurable idle window.
     required: true
     default: "pause"
   duration:
-    description: "The initial breakpoint duration. This input is ignored when mode is set to background"
+    description: "The initial breakpoint duration. Ignored when mode is 'background' or 'pause-idle'."
     required: true
     default: "30m"
   authorized-users:
@@ -32,6 +38,48 @@ inputs:
     description: "The endpoint of a breakpoint rendezvous server."
     required: true
     default: "rendezvous.namespace.so:5000"
+
+  # cozystack extensions
+  grace-period:
+    description: >
+      (pause-idle only) How long to wait for the first SSH connection before
+      giving up. Accepts Go duration syntax (e.g. '5m', '30s').
+    required: false
+    default: "5m"
+  idle-timeout:
+    description: >
+      (pause-idle only) How long with zero active SSH connections before
+      the breakpoint exits, after at least one session has connected.
+      Accepts Go duration syntax.
+    required: false
+    default: "20m"
+  comment-on-pr:
+    description: >
+      If 'true', post a pull-request comment when the SSH endpoint is detected
+      and delete it on exit. Requires 'github-token' with `pull-requests: write`
+      and a pull_request event context.
+    required: false
+    default: "false"
+  github-token:
+    description: "Token used to post and delete the PR comment. Typically the workflow's github.token or a PAT with pull-requests:write."
+    required: false
+  comment-marker:
+    description: >
+      Opaque HTML comment marker placed on the first line of the PR comment.
+      Other tools (CI watchers, AI assistants) can search the PR comment list
+      for this marker. Default: 'BREAKPOINT_OPEN'.
+    required: false
+    default: "BREAKPOINT_OPEN"
+  comment-extra-hint:
+    description: >
+      Optional extra Markdown appended to the PR comment body, useful for
+      project-specific hints (e.g. how to enter a debug sandbox).
+    required: false
+
+outputs:
+  endpoint:
+    description: "The SSH endpoint string emitted by breakpoint (e.g. 'ssh -p 40812 runner@rendezvous.namespace.so'). Empty if not detected."
+
 runs:
   using: node24
   main: dist/main/index.js

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -6755,8 +6755,8 @@ const external_node_path_namespaceObject = require("node:path");
 
 function getModeFromInput() {
     const mode = core.getInput("mode");
-    if (mode !== "pause" && mode !== "background") {
-        throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background"`);
+    if (mode !== "pause" && mode !== "background" && mode !== "pause-idle") {
+        throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background", "pause-idle"`);
     }
     return mode;
 }
@@ -6778,6 +6778,9 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 
 
 const defaultBreakpointVersion = "0.0.24";
+// Matches the "Connect with: ssh -p <PORT> <USER>@<HOST>" line emitted by
+// the breakpoint binary once the rendezvous tunnel is established.
+const sshLineRegex = /Connect with:\s*(ssh\s+-p\s+\d+\s+\S+@\S+)/;
 function getBreakpointVersion() {
     var _a;
     const override = (_a = process.env.BREAKPOINT_VERSION) === null || _a === void 0 ? void 0 : _a.trim().replace(/^v/, "");
@@ -6804,7 +6807,6 @@ function run() {
 }
 function installBreakpoint() {
     return __awaiter(this, void 0, void 0, function* () {
-        // Download the specific version of the tool, e.g. as a tarball.
         const toolURL = yield getDownloadURL();
         core.info(`Downloading: ${toolURL}`);
         const pathToTarball = yield tool_cache.downloadTool(toolURL, null, null, {
@@ -6812,11 +6814,127 @@ function installBreakpoint() {
             "User-Agent": "breakpoint-action",
             accept: "application/octet-stream",
         });
-        // Extract the tarball onto the runner.
         const pathToCLI = yield tool_cache.extractTar(pathToTarball);
-        // Expose the tool by adding it to the $PATH.
         core.addPath(pathToCLI);
     });
+}
+// State used to coordinate with post.ts for PR comment cleanup.
+const STATE_COMMENT_ID = "breakpoint_comment_id";
+const STATE_COMMENT_REPO = "breakpoint_comment_repo";
+function readCommentContext() {
+    var _a, _b, _c;
+    const enabled = core.getInput("comment-on-pr").toLowerCase() === "true";
+    if (!enabled) {
+        return null;
+    }
+    const token = core.getInput("github-token");
+    if (!token) {
+        core.warning("comment-on-pr is enabled but no github-token provided; skipping PR comment.");
+        return null;
+    }
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    const repository = process.env.GITHUB_REPOSITORY;
+    if (!eventPath || !repository) {
+        core.warning("Missing GITHUB_EVENT_PATH or GITHUB_REPOSITORY; skipping PR comment.");
+        return null;
+    }
+    let prNumber = 0;
+    try {
+        const evt = JSON.parse(external_node_fs_namespaceObject.readFileSync(eventPath, "utf8"));
+        prNumber = (_c = (_b = (_a = evt === null || evt === void 0 ? void 0 : evt.pull_request) === null || _a === void 0 ? void 0 : _a.number) !== null && _b !== void 0 ? _b : evt === null || evt === void 0 ? void 0 : evt.number) !== null && _c !== void 0 ? _c : 0;
+    }
+    catch (err) {
+        core.warning(`Failed to read event payload: ${err}`);
+        return null;
+    }
+    if (!prNumber) {
+        core.warning("No pull_request.number on the event payload; skipping PR comment.");
+        return null;
+    }
+    const [owner, repo] = repository.split("/");
+    return {
+        enabled: true,
+        token,
+        owner,
+        repo,
+        prNumber,
+        marker: core.getInput("comment-marker") || "BREAKPOINT_OPEN",
+        extraHint: core.getInput("comment-extra-hint") || "",
+    };
+}
+function buildCommentBody(ctx, endpoint, runId) {
+    const lines = [`<!-- ${ctx.marker} run=${runId} -->`, `🔴 **SSH breakpoint open**`, "", "```", endpoint, "```"];
+    if (ctx.extraHint) {
+        lines.push("", ctx.extraHint);
+    }
+    lines.push("", `_The comment is removed automatically when the breakpoint exits._`);
+    return lines.join("\n");
+}
+function postPRComment(ctx, body) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const res = yield fetch(`https://api.github.com/repos/${ctx.owner}/${ctx.repo}/issues/${ctx.prNumber}/comments`, {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${ctx.token}`,
+                    "Content-Type": "application/json",
+                    Accept: "application/vnd.github+json",
+                    "User-Agent": "breakpoint-action",
+                },
+                body: JSON.stringify({ body }),
+            });
+            if (!res.ok) {
+                const text = yield res.text();
+                core.warning(`Failed to post PR comment (${res.status}): ${text.slice(0, 200)}`);
+                return null;
+            }
+            const json = (yield res.json());
+            core.info(`Posted PR comment ${json.id}`);
+            return json.id;
+        }
+        catch (err) {
+            core.warning(`Error posting PR comment: ${err}`);
+            return null;
+        }
+    });
+}
+function makeEndpointDetector(commentCtx) {
+    let captured = "";
+    let done = false;
+    const feed = (text) => __awaiter(this, void 0, void 0, function* () {
+        if (done || !text)
+            return;
+        captured += text;
+        const match = captured.match(sshLineRegex);
+        if (!match)
+            return;
+        done = true;
+        const endpoint = match[1].trim();
+        core.setOutput("endpoint", endpoint);
+        core.notice(endpoint, { title: "SSH breakpoint endpoint" });
+        core.info(`Detected SSH endpoint: ${endpoint}`);
+        if (commentCtx) {
+            const runId = process.env.GITHUB_RUN_ID || "unknown";
+            const body = buildCommentBody(commentCtx, endpoint, runId);
+            const id = yield postPRComment(commentCtx, body);
+            if (id !== null) {
+                core.saveState(STATE_COMMENT_ID, String(id));
+                core.saveState(STATE_COMMENT_REPO, `${commentCtx.owner}/${commentCtx.repo}`);
+            }
+        }
+    });
+    const execOpts = {
+        listeners: {
+            stdout: (data) => {
+                const text = data.toString();
+                process.stdout.write(text);
+                void feed(text);
+            },
+        },
+        // We do our own writing to stdout so we don't double up.
+        silent: true,
+    };
+    return { feed, execOpts };
 }
 function runBreakpoint() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -6824,25 +6942,137 @@ function runBreakpoint() {
         const config = createConfiguration();
         const mode = getModeFromInput();
         core.debug(`Mode: ${mode}`);
-        if (mode === "background") {
-            core.info("Duration input is ignored when running in background mode");
+        if (mode === "background" || mode === "pause-idle") {
+            // Duration is managed differently in these modes.
             config.duration = "10h";
         }
-        core.debug(`Configuration: ${config}`);
-        external_node_fs_namespaceObject.writeFile(configFile, JSON.stringify(config), (err) => {
-            if (err) {
-                core.setFailed(`Failed to write config file: ${err.message}`);
+        core.debug(`Configuration: ${JSON.stringify(config)}`);
+        external_node_fs_namespaceObject.writeFileSync(configFile, JSON.stringify(config));
+        const commentCtx = readCommentContext();
+        const detector = makeEndpointDetector(commentCtx);
+        core.debug(new Date().toTimeString());
+        switch (mode) {
+            case "pause":
+                yield exec.exec(`breakpoint wait --config=${configFile}`, [], detector.execOpts);
+                break;
+            case "background":
+                yield exec.exec(`breakpoint start --config=${configFile}`, [], detector.execOpts);
+                break;
+            case "pause-idle":
+                yield runPauseIdle(configFile, detector);
+                break;
+        }
+        core.debug(new Date().toTimeString());
+    });
+}
+function parseDurationToMs(input, fallbackMs) {
+    const m = input.match(/^(\d+)\s*(ms|s|m|h)?$/);
+    if (!m)
+        return fallbackMs;
+    const n = parseInt(m[1], 10);
+    const unit = m[2] || "s";
+    switch (unit) {
+        case "ms":
+            return n;
+        case "s":
+            return n * 1000;
+        case "m":
+            return n * 60 * 1000;
+        case "h":
+            return n * 60 * 60 * 1000;
+    }
+    return fallbackMs;
+}
+// pollStatus runs `breakpoint status`, feeds its output to the endpoint
+// detector (so we surface the SSH endpoint on the first poll where it appears
+// — `breakpoint start` itself does not print it), and returns the number of
+// currently-active SSH connections. Returns null when the daemon is no longer
+// reachable.
+function pollStatus(detector) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let output = "";
+        const exitCode = yield exec.exec("breakpoint", ["status"], {
+            listeners: {
+                stdout: (data) => {
+                    output += data.toString();
+                },
+                stderr: () => { },
+            },
+            ignoreReturnCode: true,
+            silent: true,
+        });
+        if (exitCode !== 0) {
+            return null;
+        }
+        yield detector.feed(output);
+        const match = output.match(/Active connections:\s*(\d+)/);
+        return match ? parseInt(match[1], 10) : 0;
+    });
+}
+function sleep(ms) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+    });
+}
+function runPauseIdle(configFile, detector) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Start the daemon. `breakpoint start` returns once the rendezvous tunnel
+        // is up; the SSH endpoint is then printed by `breakpoint status` (which we
+        // poll below), not by `start` itself.
+        yield exec.exec(`breakpoint start --config=${configFile}`, [], detector.execOpts);
+        const graceMs = parseDurationToMs(core.getInput("grace-period") || "5m", 5 * 60 * 1000);
+        const idleMs = parseDurationToMs(core.getInput("idle-timeout") || "20m", 20 * 60 * 1000);
+        const pollMs = 5000;
+        core.info(`pause-idle: grace=${graceMs}ms, idle-timeout=${idleMs}ms (waiting for first SSH connection)`);
+        // Phase 1: wait for the first connection, up to grace-period.
+        const graceDeadline = Date.now() + graceMs;
+        let everConnected = false;
+        while (Date.now() < graceDeadline) {
+            const conns = yield pollStatus(detector);
+            if (conns === null) {
+                core.info("breakpoint daemon is no longer reachable; exiting pause-idle");
                 return;
             }
-        });
-        core.debug(new Date().toTimeString());
-        if (mode === "pause") {
-            yield exec.exec(`breakpoint wait --config=${configFile}`);
+            if (conns > 0) {
+                everConnected = true;
+                core.info(`pause-idle: SSH session connected (${conns} active), entering idle-aware wait`);
+                break;
+            }
+            yield sleep(pollMs);
         }
-        else {
-            yield exec.exec(`breakpoint start --config=${configFile}`);
+        if (!everConnected) {
+            core.info("pause-idle: no SSH connection during grace period, stopping breakpoint");
+            yield stopBreakpoint();
+            return;
         }
-        core.debug(new Date().toTimeString());
+        // Phase 2: keep going while connected; exit after idle-timeout of zero connections.
+        let lastSeenConnectedAt = Date.now();
+        while (true) {
+            const conns = yield pollStatus(detector);
+            if (conns === null) {
+                core.info("breakpoint daemon stopped externally; exiting pause-idle");
+                return;
+            }
+            if (conns > 0) {
+                lastSeenConnectedAt = Date.now();
+            }
+            else if (Date.now() - lastSeenConnectedAt > idleMs) {
+                core.info(`pause-idle: idle for ${idleMs}ms with no connections, stopping breakpoint`);
+                yield stopBreakpoint();
+                return;
+            }
+            yield sleep(pollMs);
+        }
+    });
+}
+function stopBreakpoint() {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            yield exec.exec("breakpoint", ["resume"], { ignoreReturnCode: true, silent: true });
+        }
+        catch (err) {
+            core.debug(`Error stopping breakpoint: ${err}`);
+        }
     });
 }
 function getDownloadURL() {

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -4110,8 +4110,8 @@ var exec = __nccwpck_require__(514);
 
 function getModeFromInput() {
     const mode = core.getInput("mode");
-    if (mode !== "pause" && mode !== "background") {
-        throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background"`);
+    if (mode !== "pause" && mode !== "background" && mode !== "pause-idle") {
+        throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background", "pause-idle"`);
     }
     return mode;
 }
@@ -4129,6 +4129,37 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 
 
 
+const STATE_COMMENT_ID = "breakpoint_comment_id";
+const STATE_COMMENT_REPO = "breakpoint_comment_repo";
+function deletePRComment() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const commentId = core.getState(STATE_COMMENT_ID);
+        const repo = core.getState(STATE_COMMENT_REPO);
+        const token = core.getInput("github-token");
+        if (!commentId || !repo || !token) {
+            return;
+        }
+        try {
+            const res = yield fetch(`https://api.github.com/repos/${repo}/issues/comments/${commentId}`, {
+                method: "DELETE",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    Accept: "application/vnd.github+json",
+                    "User-Agent": "breakpoint-action",
+                },
+            });
+            if (!res.ok && res.status !== 404) {
+                const text = yield res.text();
+                core.warning(`Failed to delete PR comment (${res.status}): ${text.slice(0, 200)}`);
+                return;
+            }
+            core.info(`Deleted PR comment ${commentId}`);
+        }
+        catch (err) {
+            core.warning(`Error deleting PR comment: ${err}`);
+        }
+    });
+}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -4143,6 +4174,8 @@ function run() {
             core.info("Error encountered while waiting for breakpoint to finish, it might've been stopped manually");
             core.debug(err);
         }
+        // Always try cleanup, regardless of mode or whether the action errored.
+        yield deletePRComment();
     });
 }
 run();

--- a/lib.ts
+++ b/lib.ts
@@ -1,10 +1,11 @@
 import * as core from "@actions/core";
 
-export function getModeFromInput() {
-	const mode = core.getInput("mode");
-	if (mode !== "pause" && mode !== "background") {
-		throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background"`);
-	}
+export type Mode = "pause" | "background" | "pause-idle";
 
+export function getModeFromInput(): Mode {
+	const mode = core.getInput("mode");
+	if (mode !== "pause" && mode !== "background" && mode !== "pause-idle") {
+		throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background", "pause-idle"`);
+	}
 	return mode;
 }

--- a/main.ts
+++ b/main.ts
@@ -3,9 +3,13 @@ import * as exec from "@actions/exec";
 import * as tc from "@actions/tool-cache";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getModeFromInput } from "./lib";
+import { getModeFromInput, Mode } from "./lib";
 
 const defaultBreakpointVersion = "0.0.24";
+
+// Matches the "Connect with: ssh -p <PORT> <USER>@<HOST>" line emitted by
+// the breakpoint binary once the rendezvous tunnel is established.
+const sshLineRegex = /Connect with:\s*(ssh\s+-p\s+\d+\s+\S+@\S+)/;
 
 function getBreakpointVersion(): string {
 	const override = process.env.BREAKPOINT_VERSION?.trim().replace(/^v/, "");
@@ -47,7 +51,6 @@ async function run(): Promise<void> {
 }
 
 async function installBreakpoint(): Promise<void> {
-	// Download the specific version of the tool, e.g. as a tarball.
 	const toolURL = await getDownloadURL();
 	core.info(`Downloading: ${toolURL}`);
 
@@ -57,42 +60,296 @@ async function installBreakpoint(): Promise<void> {
 		accept: "application/octet-stream",
 	});
 
-	// Extract the tarball onto the runner.
 	const pathToCLI = await tc.extractTar(pathToTarball);
-
-	// Expose the tool by adding it to the $PATH.
 	core.addPath(pathToCLI);
+}
+
+// State used to coordinate with post.ts for PR comment cleanup.
+const STATE_COMMENT_ID = "breakpoint_comment_id";
+const STATE_COMMENT_REPO = "breakpoint_comment_repo";
+
+interface CommentContext {
+	enabled: boolean;
+	token: string;
+	owner: string;
+	repo: string;
+	prNumber: number;
+	marker: string;
+	extraHint: string;
+}
+
+function readCommentContext(): CommentContext | null {
+	const enabled = core.getInput("comment-on-pr").toLowerCase() === "true";
+	if (!enabled) {
+		return null;
+	}
+
+	const token = core.getInput("github-token");
+	if (!token) {
+		core.warning("comment-on-pr is enabled but no github-token provided; skipping PR comment.");
+		return null;
+	}
+
+	const eventPath = process.env.GITHUB_EVENT_PATH;
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!eventPath || !repository) {
+		core.warning("Missing GITHUB_EVENT_PATH or GITHUB_REPOSITORY; skipping PR comment.");
+		return null;
+	}
+
+	let prNumber = 0;
+	try {
+		const evt = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+		prNumber = evt?.pull_request?.number ?? evt?.number ?? 0;
+	} catch (err) {
+		core.warning(`Failed to read event payload: ${err}`);
+		return null;
+	}
+	if (!prNumber) {
+		core.warning("No pull_request.number on the event payload; skipping PR comment.");
+		return null;
+	}
+
+	const [owner, repo] = repository.split("/");
+	return {
+		enabled: true,
+		token,
+		owner,
+		repo,
+		prNumber,
+		marker: core.getInput("comment-marker") || "BREAKPOINT_OPEN",
+		extraHint: core.getInput("comment-extra-hint") || "",
+	};
+}
+
+function buildCommentBody(ctx: CommentContext, endpoint: string, runId: string): string {
+	const lines = [`<!-- ${ctx.marker} run=${runId} -->`, `🔴 **SSH breakpoint open**`, "", "```", endpoint, "```"];
+	if (ctx.extraHint) {
+		lines.push("", ctx.extraHint);
+	}
+	lines.push("", `_The comment is removed automatically when the breakpoint exits._`);
+	return lines.join("\n");
+}
+
+async function postPRComment(ctx: CommentContext, body: string): Promise<number | null> {
+	try {
+		const res = await fetch(`https://api.github.com/repos/${ctx.owner}/${ctx.repo}/issues/${ctx.prNumber}/comments`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${ctx.token}`,
+				"Content-Type": "application/json",
+				Accept: "application/vnd.github+json",
+				"User-Agent": "breakpoint-action",
+			},
+			body: JSON.stringify({ body }),
+		});
+		if (!res.ok) {
+			const text = await res.text();
+			core.warning(`Failed to post PR comment (${res.status}): ${text.slice(0, 200)}`);
+			return null;
+		}
+		const json = (await res.json()) as { id: number };
+		core.info(`Posted PR comment ${json.id}`);
+		return json.id;
+	} catch (err) {
+		core.warning(`Error posting PR comment: ${err}`);
+		return null;
+	}
+}
+
+// EndpointDetector centralises the "watch breakpoint output, surface the SSH
+// endpoint" logic. The same detector is fed both by stdout listeners of
+// long-running `breakpoint wait`/`breakpoint start` calls and by the output
+// of periodic `breakpoint status` polls during `pause-idle`.
+interface EndpointDetector {
+	feed: (text: string) => Promise<void>;
+	execOpts: exec.ExecOptions;
+}
+
+function makeEndpointDetector(commentCtx: CommentContext | null): EndpointDetector {
+	let captured = "";
+	let done = false;
+
+	const feed = async (text: string): Promise<void> => {
+		if (done || !text) return;
+		captured += text;
+		const match = captured.match(sshLineRegex);
+		if (!match) return;
+
+		done = true;
+		const endpoint = match[1].trim();
+		core.setOutput("endpoint", endpoint);
+		core.notice(endpoint, { title: "SSH breakpoint endpoint" });
+		core.info(`Detected SSH endpoint: ${endpoint}`);
+
+		if (commentCtx) {
+			const runId = process.env.GITHUB_RUN_ID || "unknown";
+			const body = buildCommentBody(commentCtx, endpoint, runId);
+			const id = await postPRComment(commentCtx, body);
+			if (id !== null) {
+				core.saveState(STATE_COMMENT_ID, String(id));
+				core.saveState(STATE_COMMENT_REPO, `${commentCtx.owner}/${commentCtx.repo}`);
+			}
+		}
+	};
+
+	const execOpts: exec.ExecOptions = {
+		listeners: {
+			stdout: (data: Buffer) => {
+				const text = data.toString();
+				process.stdout.write(text);
+				void feed(text);
+			},
+		},
+		// We do our own writing to stdout so we don't double up.
+		silent: true,
+	};
+
+	return { feed, execOpts };
 }
 
 async function runBreakpoint(): Promise<void> {
 	const configFile = tmpFile("config.json");
 	const config = createConfiguration();
-
 	const mode = getModeFromInput();
 
 	core.debug(`Mode: ${mode}`);
 
-	if (mode === "background") {
-		core.info("Duration input is ignored when running in background mode");
+	if (mode === "background" || mode === "pause-idle") {
+		// Duration is managed differently in these modes.
 		config.duration = "10h";
 	}
 
-	core.debug(`Configuration: ${config}`);
+	core.debug(`Configuration: ${JSON.stringify(config)}`);
+	fs.writeFileSync(configFile, JSON.stringify(config));
 
-	fs.writeFile(configFile, JSON.stringify(config), (err) => {
-		if (err) {
-			core.setFailed(`Failed to write config file: ${err.message}`);
-			return;
-		}
-	});
+	const commentCtx = readCommentContext();
+	const detector = makeEndpointDetector(commentCtx);
 
 	core.debug(new Date().toTimeString());
-	if (mode === "pause") {
-		await exec.exec(`breakpoint wait --config=${configFile}`);
-	} else {
-		await exec.exec(`breakpoint start --config=${configFile}`);
+	switch (mode) {
+		case "pause":
+			await exec.exec(`breakpoint wait --config=${configFile}`, [], detector.execOpts);
+			break;
+
+		case "background":
+			await exec.exec(`breakpoint start --config=${configFile}`, [], detector.execOpts);
+			break;
+
+		case "pause-idle":
+			await runPauseIdle(configFile, detector);
+			break;
 	}
 	core.debug(new Date().toTimeString());
+}
+
+function parseDurationToMs(input: string, fallbackMs: number): number {
+	const m = input.match(/^(\d+)\s*(ms|s|m|h)?$/);
+	if (!m) return fallbackMs;
+	const n = parseInt(m[1], 10);
+	const unit = m[2] || "s";
+	switch (unit) {
+		case "ms":
+			return n;
+		case "s":
+			return n * 1000;
+		case "m":
+			return n * 60 * 1000;
+		case "h":
+			return n * 60 * 60 * 1000;
+	}
+	return fallbackMs;
+}
+
+// pollStatus runs `breakpoint status`, feeds its output to the endpoint
+// detector (so we surface the SSH endpoint on the first poll where it appears
+// — `breakpoint start` itself does not print it), and returns the number of
+// currently-active SSH connections. Returns null when the daemon is no longer
+// reachable.
+async function pollStatus(detector: EndpointDetector): Promise<number | null> {
+	let output = "";
+	const exitCode = await exec.exec("breakpoint", ["status"], {
+		listeners: {
+			stdout: (data: Buffer) => {
+				output += data.toString();
+			},
+			stderr: () => {},
+		},
+		ignoreReturnCode: true,
+		silent: true,
+	});
+	if (exitCode !== 0) {
+		return null;
+	}
+	await detector.feed(output);
+	const match = output.match(/Active connections:\s*(\d+)/);
+	return match ? parseInt(match[1], 10) : 0;
+}
+
+async function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runPauseIdle(configFile: string, detector: EndpointDetector): Promise<void> {
+	// Start the daemon. `breakpoint start` returns once the rendezvous tunnel
+	// is up; the SSH endpoint is then printed by `breakpoint status` (which we
+	// poll below), not by `start` itself.
+	await exec.exec(`breakpoint start --config=${configFile}`, [], detector.execOpts);
+
+	const graceMs = parseDurationToMs(core.getInput("grace-period") || "5m", 5 * 60 * 1000);
+	const idleMs = parseDurationToMs(core.getInput("idle-timeout") || "20m", 20 * 60 * 1000);
+	const pollMs = 5000;
+
+	core.info(`pause-idle: grace=${graceMs}ms, idle-timeout=${idleMs}ms (waiting for first SSH connection)`);
+
+	// Phase 1: wait for the first connection, up to grace-period.
+	const graceDeadline = Date.now() + graceMs;
+	let everConnected = false;
+	while (Date.now() < graceDeadline) {
+		const conns = await pollStatus(detector);
+		if (conns === null) {
+			core.info("breakpoint daemon is no longer reachable; exiting pause-idle");
+			return;
+		}
+		if (conns > 0) {
+			everConnected = true;
+			core.info(`pause-idle: SSH session connected (${conns} active), entering idle-aware wait`);
+			break;
+		}
+		await sleep(pollMs);
+	}
+
+	if (!everConnected) {
+		core.info("pause-idle: no SSH connection during grace period, stopping breakpoint");
+		await stopBreakpoint();
+		return;
+	}
+
+	// Phase 2: keep going while connected; exit after idle-timeout of zero connections.
+	let lastSeenConnectedAt = Date.now();
+	while (true) {
+		const conns = await pollStatus(detector);
+		if (conns === null) {
+			core.info("breakpoint daemon stopped externally; exiting pause-idle");
+			return;
+		}
+		if (conns > 0) {
+			lastSeenConnectedAt = Date.now();
+		} else if (Date.now() - lastSeenConnectedAt > idleMs) {
+			core.info(`pause-idle: idle for ${idleMs}ms with no connections, stopping breakpoint`);
+			await stopBreakpoint();
+			return;
+		}
+		await sleep(pollMs);
+	}
+}
+
+async function stopBreakpoint(): Promise<void> {
+	try {
+		await exec.exec("breakpoint", ["resume"], { ignoreReturnCode: true, silent: true });
+	} catch (err) {
+		core.debug(`Error stopping breakpoint: ${err}`);
+	}
 }
 
 async function getDownloadURL(): Promise<string> {

--- a/post.ts
+++ b/post.ts
@@ -2,6 +2,38 @@ import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import { getModeFromInput } from "./lib";
 
+const STATE_COMMENT_ID = "breakpoint_comment_id";
+const STATE_COMMENT_REPO = "breakpoint_comment_repo";
+
+async function deletePRComment(): Promise<void> {
+	const commentId = core.getState(STATE_COMMENT_ID);
+	const repo = core.getState(STATE_COMMENT_REPO);
+	const token = core.getInput("github-token");
+
+	if (!commentId || !repo || !token) {
+		return;
+	}
+
+	try {
+		const res = await fetch(`https://api.github.com/repos/${repo}/issues/comments/${commentId}`, {
+			method: "DELETE",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"User-Agent": "breakpoint-action",
+			},
+		});
+		if (!res.ok && res.status !== 404) {
+			const text = await res.text();
+			core.warning(`Failed to delete PR comment (${res.status}): ${text.slice(0, 200)}`);
+			return;
+		}
+		core.info(`Deleted PR comment ${commentId}`);
+	} catch (err) {
+		core.warning(`Error deleting PR comment: ${err}`);
+	}
+}
+
 async function run(): Promise<void> {
 	try {
 		const mode = getModeFromInput();
@@ -15,6 +47,9 @@ async function run(): Promise<void> {
 		core.info("Error encountered while waiting for breakpoint to finish, it might've been stopped manually");
 		core.debug(err);
 	}
+
+	// Always try cleanup, regardless of mode or whether the action errored.
+	await deletePRComment();
 }
 
 run();


### PR DESCRIPTION
## Motivation

When `breakpoint-action` is wired into a CI pipeline (e.g. fail-on-test, with operators not necessarily watching the run live), three friction points come up:

1. **Endpoint discovery.** The SSH endpoint is printed to the step log, but GitHub buffers per-step logs until the step concludes — which for `mode: pause` is exactly when the breakpoint ends. From the outside, the endpoint is invisible while it would be useful.
2. **Fixed timeouts are wasteful or short.** A fixed `duration` either burns runner time when nobody attaches, or expires while a debug session is mid-investigation.
3. **No structured signal to other tooling.** External watchers (CI dashboards, AI assistants reviewing PRs) have no canonical way to know "a breakpoint is open on this PR; here's how to reach it".

## Changes

Three coherent, opt-in features:

### 1. `endpoint` step output + `::notice::` annotation
The action now parses `breakpoint`'s stdout for `Connect with: ssh -p <port> <user>@<host>` and on first match:
- Sets `core.setOutput("endpoint", ...)` for following steps.
- Emits `core.notice(endpoint, { title: ... })`. Check Run annotations are queryable via the REST API while the run is still in progress — closest thing to live log streaming the GitHub API offers.

### 2. `mode: pause-idle`
Pauses for `grace-period` (default 5m) waiting for the first SSH connection, then keeps the workflow paused while sessions are active, and exits after `idle-timeout` (default 20m) of zero connections. Implemented as `breakpoint start` + a polling loop on `breakpoint status`. Existing `pause`/`background` unchanged.

### 3. Optional PR-comment notification
New inputs: `comment-on-pr`, `github-token`, `comment-marker`, `comment-extra-hint`. When enabled in a `pull_request` event context, the action posts a comment with the SSH endpoint as soon as it is detected and deletes it in the `post:` step. Marker is configurable so external tooling can search for it. Default disabled.

## Risk

Implementation is additive. No existing input/output semantic changed. README updated. `dist/` rebuilt with `npm run build`. `prettier`/`eslint` clean.

## Splitting

Happy to split into three smaller PRs if you prefer — they share motivation but are technically independent.