### PR TITLE
Add endpoint output, pause-idle mode, and Check Run signaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,66 @@ When Breakpoint activates, it will output on a regular basis how much time left 
 └───────────────────────────────────────────────────────────────────────────┘
 ```
 
+### Pause with idle-aware timeout
+
+`mode: pause-idle` pauses the workflow until either (a) no SSH session has
+connected within `grace-period`, or (b) a session connected and then all
+sessions have been disconnected for longer than `idle-timeout`. Useful when
+you want "long enough for a human to attach if they're around, no longer
+than necessary if they're not".
+
+```yaml
+- name: Pause with idle-aware timeout
+  if: failure()
+  uses: namespacelabs/breakpoint-action@v0
+  with:
+    mode: pause-idle
+    grace-period: 20m   # default
+    idle-timeout: 10m   # default
+    authorized-users: jack123, alice321
+```
+
+### Surfacing the SSH endpoint to external tooling
+
+The action emits the SSH connection string (`Connect with: ssh -p ... runner@...`)
+to the step log, but GitHub buffers step logs until the step completes — which
+for `pause`-style modes means the endpoint is invisible until the breakpoint
+ends. To make the endpoint observable while the step is still active, the
+action:
+
+- Sets a step output `endpoint`, e.g. `${{ steps.bp.outputs.endpoint }}`.
+- Emits a Check Run annotation via `::notice::`, visible in the run summary
+  and queryable through the REST API while the run is in progress.
+- Optionally creates a dedicated **Check Run** with conclusion `failure` and
+  the endpoint embedded in `output.summary`. This surfaces as a standard
+  failed check on the PR (a red ✗ in `gh pr checks`) so any tooling that
+  watches CI by name sees it immediately, without bespoke marker parsing.
+  When the breakpoint exits, the action updates the Check Run to
+  `conclusion: success` (or whatever `check-run-conclusion-on-resume`
+  specifies).
+
+```yaml
+- name: Pause on failure with Check Run signal
+  if: failure() && github.event_name == 'pull_request'
+  id: bp
+  uses: namespacelabs/breakpoint-action@v0
+  with:
+    mode: pause-idle
+    authorized-users: jack123, alice321
+    check-run-name: "Breakpoint Open"
+    github-token: ${{ github.token }}
+    check-run-summary-template: |
+      ## SSH breakpoint open
+      ```
+      {endpoint}
+      ```
+      Run inside the SSH session:
+      `docker exec -ti $(docker ps --filter name=my-sandbox -q | head -1) bash`
+```
+
+Requires `permissions: checks: write` on the calling job so the action can
+create and update Check Runs.
+
 ### Run in the background
 
 Breakpoint can also be started in the background to allow connecting at any point during the workflow.
@@ -123,11 +183,40 @@ This action offers inputs that you can use to configure `breakpoint` behavior:
 
   The default value is "30m".
 
-- `mode` - is the mode that breakpoint is started with. Either _pause_ (the default)
-  or _background_. When running in the background, Breakpoint won't block your workflow.
-  The duration input will have no effect when running in the background.
+- `mode` - is the mode that breakpoint is started with. Either _pause_ (the default),
+  _background_ or _pause-idle_. _pause_ blocks until duration is reached or the user
+  resumes. _background_ won't block your workflow (and the duration input is ignored).
+  _pause-idle_ blocks while there are active SSH connections, with a `grace-period`
+  for the first connection and an `idle-timeout` after the last one.
 
   The default value is "pause"
+
+- `grace-period` - (pause-idle only) how long to wait for the first SSH connection
+  before giving up. Accepts Go duration syntax (e.g. `20m`, `30s`).
+
+  The default value is "20m".
+
+- `idle-timeout` - (pause-idle only) how long with zero active SSH connections
+  before the breakpoint exits, after at least one session has connected.
+
+  The default value is "10m".
+
+- `check-run-name` - if set, the action creates a Check Run with this name when
+  the SSH endpoint is detected, marks it `conclusion: failure` with the
+  endpoint in `output.summary`, and updates it on exit. Requires
+  `github-token` and `permissions: checks: write`. Leave empty to disable.
+
+- `check-run-summary-template` - Markdown template for the Check Run's
+  `output.summary`. The placeholder `{endpoint}` is replaced with the SSH
+  connect string. Defaults to a minimal summary with just the endpoint.
+
+- `check-run-conclusion-on-resume` - conclusion to set when the Check Run is
+  updated on breakpoint exit. One of `success`, `neutral`, `skipped`.
+
+  The default value is "success".
+
+- `github-token` - token used for the Check Run API calls. Typically the
+  workflow's `github.token`.
 
 - `authorized-users` - is the comma-separated list of GitHub users that would be
   allowed to SSH into a GitHub Runner. GitHub users would need to have their
@@ -163,3 +252,9 @@ This action offers inputs that you can use to configure `breakpoint` behavior:
 Note, that `authorized-users` and `authorized-keys` used to provided SSH access
 to a GitHub Runner. The action will fail if neither `authorized-users` nor
 `authorized-keys` is provided.
+
+## Outputs
+
+- `endpoint` - the SSH endpoint string emitted by breakpoint
+  (e.g. `ssh -p 40812 runner@rendezvous.namespace.so`), or empty if it was
+  not detected before the step finished.

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,22 @@
 name: 'Add a breakpoint to CI'
 description: 'Pause, debug with SSH and resume GitHub Actions'
-author: 'Namespace Labs'
+author: 'Namespace Labs (fork by Cozystack)'
 branding:
   icon: 'pause-circle'
   color: 'blue'
 inputs:
   mode:
-    description: "One of 'pause' or 'background'. 'pause' will pause your workflow until you tell it to continue (or duration is reached). 'background' will run in the background allowing you to connect at any time during your workflow"
+    description: >
+      One of 'pause', 'background', or 'pause-idle'. 'pause' pauses the workflow
+      until you resume it (or duration is reached). 'background' runs in the
+      background allowing you to connect at any time during your workflow.
+      'pause-idle' (cozystack extension) pauses for an initial grace period to
+      wait for the first SSH connection, then keeps the workflow paused while
+      any SSH session is active and exits after a configurable idle window.
     required: true
     default: "pause"
   duration:
-    description: "The initial breakpoint duration. This input is ignored when mode is set to background"
+    description: "The initial breakpoint duration. Ignored when mode is 'background' or 'pause-idle'."
     required: true
     default: "30m"
   authorized-users:
@@ -32,6 +38,52 @@ inputs:
     description: "The endpoint of a breakpoint rendezvous server."
     required: true
     default: "rendezvous.namespace.so:5000"
+
+  # cozystack extensions
+  grace-period:
+    description: >
+      (pause-idle only) How long to wait for the first SSH connection before
+      giving up. Accepts Go duration syntax (e.g. '20m', '30s').
+    required: false
+    default: "20m"
+  idle-timeout:
+    description: >
+      (pause-idle only) How long with zero active SSH connections before
+      the breakpoint exits, after at least one session has connected.
+      Accepts Go duration syntax.
+    required: false
+    default: "10m"
+  check-run-name:
+    description: >
+      If set, the action creates a separate GitHub Check Run with this name
+      when the SSH endpoint is detected, marks it as conclusion=failure with
+      the endpoint embedded in output.summary, and updates it to
+      conclusion=success (or check-run-conclusion-on-resume) when the
+      breakpoint exits. Gives a standard CI-failure signal that any tooling
+      can detect via `gh pr checks` without bespoke marker parsing. Leave
+      empty to disable.
+    required: false
+  check-run-summary-template:
+    description: >
+      Markdown template for the Check Run's output.summary while the
+      breakpoint is open. The placeholder '{endpoint}' is replaced with the
+      SSH connect string. Defaults to a minimal summary containing just the
+      endpoint in a code block.
+    required: false
+  check-run-conclusion-on-resume:
+    description: >
+      Conclusion to set on the Check Run when the breakpoint exits. One of
+      'success', 'neutral', 'skipped'.
+    required: false
+    default: "success"
+  github-token:
+    description: "Token used for Check Run API operations (requires checks:write). Typically the workflow's github.token."
+    required: false
+
+outputs:
+  endpoint:
+    description: "The SSH endpoint string emitted by breakpoint (e.g. 'ssh -p 40812 runner@rendezvous.namespace.so'). Empty if not detected."
+
 runs:
   using: node24
   main: dist/main/index.js

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -6755,8 +6755,8 @@ const external_node_path_namespaceObject = require("node:path");
 
 function getModeFromInput() {
     const mode = core.getInput("mode");
-    if (mode !== "pause" && mode !== "background") {
-        throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background"`);
+    if (mode !== "pause" && mode !== "background" && mode !== "pause-idle") {
+        throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background", "pause-idle"`);
     }
     return mode;
 }
@@ -6778,6 +6778,11 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 
 
 const defaultBreakpointVersion = "0.0.24";
+// Matches the "Connect with: ssh -p <PORT> <USER>@<HOST>" line emitted by
+// the breakpoint binary once the rendezvous tunnel is established.
+const sshLineRegex = /Connect with:\s*(ssh\s+-p\s+\d+\s+\S+@\S+)/;
+const STATE_CHECK_RUN_ID = "breakpoint_check_run_id";
+const STATE_CHECK_RUN_REPO = "breakpoint_check_run_repo";
 function getBreakpointVersion() {
     var _a;
     const override = (_a = process.env.BREAKPOINT_VERSION) === null || _a === void 0 ? void 0 : _a.trim().replace(/^v/, "");
@@ -6804,7 +6809,6 @@ function run() {
 }
 function installBreakpoint() {
     return __awaiter(this, void 0, void 0, function* () {
-        // Download the specific version of the tool, e.g. as a tarball.
         const toolURL = yield getDownloadURL();
         core.info(`Downloading: ${toolURL}`);
         const pathToTarball = yield tool_cache.downloadTool(toolURL, null, null, {
@@ -6812,39 +6816,278 @@ function installBreakpoint() {
             "User-Agent": "breakpoint-action",
             accept: "application/octet-stream",
         });
-        // Extract the tarball onto the runner.
         const pathToCLI = yield tool_cache.extractTar(pathToTarball);
-        // Expose the tool by adding it to the $PATH.
         core.addPath(pathToCLI);
     });
 }
+function readCheckRunContext() {
+    const name = core.getInput("check-run-name");
+    if (!name) {
+        return null;
+    }
+    const token = core.getInput("github-token");
+    if (!token) {
+        core.warning("check-run-name is set but no github-token provided; skipping Check Run signal.");
+        return null;
+    }
+    const repository = process.env.GITHUB_REPOSITORY;
+    if (!repository) {
+        core.warning("Missing GITHUB_REPOSITORY; skipping Check Run signal.");
+        return null;
+    }
+    const [owner, repo] = repository.split("/");
+    const headSha = resolveHeadSha();
+    if (!headSha) {
+        core.warning("Could not determine head SHA; skipping Check Run signal.");
+        return null;
+    }
+    return {
+        name,
+        summaryTemplate: core.getInput("check-run-summary-template") || "## SSH breakpoint open\n\n```\n{endpoint}\n```",
+        token,
+        owner,
+        repo,
+        headSha,
+    };
+}
+// In pull_request workflows, GITHUB_SHA is the merge commit. Check Runs need
+// the PR head SHA so they surface on the PR's Checks tab — pull it from the
+// event payload when present, fall back to GITHUB_SHA otherwise.
+function resolveHeadSha() {
+    var _a, _b;
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (eventPath) {
+        try {
+            const evt = JSON.parse(external_node_fs_namespaceObject.readFileSync(eventPath, "utf8"));
+            const prHead = (_b = (_a = evt === null || evt === void 0 ? void 0 : evt.pull_request) === null || _a === void 0 ? void 0 : _a.head) === null || _b === void 0 ? void 0 : _b.sha;
+            if (prHead)
+                return prHead;
+        }
+        catch (err) {
+            core.debug(`Failed to read event payload: ${err}`);
+        }
+    }
+    return process.env.GITHUB_SHA || null;
+}
+function createBreakpointCheckRun(ctx, endpoint) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const summary = ctx.summaryTemplate.split("{endpoint}").join(endpoint);
+        const body = {
+            name: ctx.name,
+            head_sha: ctx.headSha,
+            status: "completed",
+            conclusion: "failure",
+            output: {
+                title: "SSH breakpoint open — paused for debug",
+                summary,
+            },
+        };
+        try {
+            const res = yield fetch(`https://api.github.com/repos/${ctx.owner}/${ctx.repo}/check-runs`, {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${ctx.token}`,
+                    Accept: "application/vnd.github+json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "breakpoint-action",
+                },
+                body: JSON.stringify(body),
+            });
+            if (!res.ok) {
+                const text = yield res.text();
+                core.warning(`Failed to create Check Run (${res.status}): ${text.slice(0, 200)}`);
+                return null;
+            }
+            const json = (yield res.json());
+            core.info(`Created Check Run ${json.id} ("${ctx.name}") with conclusion=failure`);
+            return json.id;
+        }
+        catch (err) {
+            core.warning(`Error creating Check Run: ${err}`);
+            return null;
+        }
+    });
+}
+function makeEndpointDetector(checkRunCtx) {
+    let captured = "";
+    let done = false;
+    const feed = (text) => __awaiter(this, void 0, void 0, function* () {
+        if (done || !text)
+            return;
+        captured += text;
+        const match = captured.match(sshLineRegex);
+        if (!match)
+            return;
+        done = true;
+        const endpoint = match[1].trim();
+        core.setOutput("endpoint", endpoint);
+        core.notice(endpoint, { title: "SSH breakpoint endpoint" });
+        core.info(`Detected SSH endpoint: ${endpoint}`);
+        if (checkRunCtx) {
+            const id = yield createBreakpointCheckRun(checkRunCtx, endpoint);
+            if (id !== null) {
+                core.saveState(STATE_CHECK_RUN_ID, String(id));
+                core.saveState(STATE_CHECK_RUN_REPO, `${checkRunCtx.owner}/${checkRunCtx.repo}`);
+            }
+        }
+    });
+    const execOpts = {
+        listeners: {
+            stdout: (data) => {
+                const text = data.toString();
+                process.stdout.write(text);
+                void feed(text);
+            },
+        },
+        // We do our own writing to stdout so we don't double up.
+        silent: true,
+    };
+    return { feed, execOpts };
+}
+// -------------------- Mode dispatch --------------------
 function runBreakpoint() {
     return __awaiter(this, void 0, void 0, function* () {
         const configFile = tmpFile("config.json");
         const config = createConfiguration();
         const mode = getModeFromInput();
         core.debug(`Mode: ${mode}`);
-        if (mode === "background") {
-            core.info("Duration input is ignored when running in background mode");
+        if (mode === "background" || mode === "pause-idle") {
+            // Duration is managed differently in these modes.
             config.duration = "10h";
         }
-        core.debug(`Configuration: ${config}`);
-        external_node_fs_namespaceObject.writeFile(configFile, JSON.stringify(config), (err) => {
-            if (err) {
-                core.setFailed(`Failed to write config file: ${err.message}`);
-                return;
-            }
-        });
+        core.debug(`Configuration: ${JSON.stringify(config)}`);
+        // Write the file synchronously — the original async version had a race
+        // against the immediately-following exec.
+        external_node_fs_namespaceObject.writeFileSync(configFile, JSON.stringify(config));
+        const checkRunCtx = readCheckRunContext();
+        const detector = makeEndpointDetector(checkRunCtx);
         core.debug(new Date().toTimeString());
-        if (mode === "pause") {
-            yield exec.exec(`breakpoint wait --config=${configFile}`);
-        }
-        else {
-            yield exec.exec(`breakpoint start --config=${configFile}`);
+        switch (mode) {
+            case "pause":
+                yield exec.exec(`breakpoint wait --config=${configFile}`, [], detector.execOpts);
+                break;
+            case "background":
+                yield exec.exec(`breakpoint start --config=${configFile}`, [], detector.execOpts);
+                break;
+            case "pause-idle":
+                yield runPauseIdle(configFile, detector);
+                break;
         }
         core.debug(new Date().toTimeString());
     });
 }
+// -------------------- pause-idle implementation --------------------
+function parseDurationToMs(input, fallbackMs) {
+    const m = input.match(/^(\d+)\s*(ms|s|m|h)?$/);
+    if (!m)
+        return fallbackMs;
+    const n = parseInt(m[1], 10);
+    const unit = m[2] || "s";
+    switch (unit) {
+        case "ms":
+            return n;
+        case "s":
+            return n * 1000;
+        case "m":
+            return n * 60 * 1000;
+        case "h":
+            return n * 60 * 60 * 1000;
+    }
+    return fallbackMs;
+}
+// pollStatus runs `breakpoint status`, feeds its output to the endpoint
+// detector (so we surface the SSH endpoint on the first poll where it appears
+// — `breakpoint start` itself does not print it), and returns the number of
+// currently-active SSH connections. Returns null when the daemon is no longer
+// reachable.
+function pollStatus(detector) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let output = "";
+        const exitCode = yield exec.exec("breakpoint", ["status"], {
+            listeners: {
+                stdout: (data) => {
+                    output += data.toString();
+                },
+                stderr: () => {
+                    /* swallow */
+                },
+            },
+            ignoreReturnCode: true,
+            silent: true,
+        });
+        if (exitCode !== 0) {
+            return null;
+        }
+        yield detector.feed(output);
+        const match = output.match(/Active connections:\s*(\d+)/);
+        return match ? parseInt(match[1], 10) : 0;
+    });
+}
+function sleep(ms) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+    });
+}
+function runPauseIdle(configFile, detector) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Start the daemon. `breakpoint start` returns once the rendezvous tunnel
+        // is up; the SSH endpoint is then printed by `breakpoint status` (which we
+        // poll below), not by `start` itself.
+        yield exec.exec(`breakpoint start --config=${configFile}`, [], detector.execOpts);
+        const graceMs = parseDurationToMs(core.getInput("grace-period") || "20m", 20 * 60 * 1000);
+        const idleMs = parseDurationToMs(core.getInput("idle-timeout") || "10m", 10 * 60 * 1000);
+        const pollMs = 5000;
+        core.info(`pause-idle: grace=${graceMs}ms, idle-timeout=${idleMs}ms (waiting for first SSH connection)`);
+        const graceDeadline = Date.now() + graceMs;
+        let everConnected = false;
+        while (Date.now() < graceDeadline) {
+            const conns = yield pollStatus(detector);
+            if (conns === null) {
+                core.info("breakpoint daemon is no longer reachable; exiting pause-idle");
+                return;
+            }
+            if (conns > 0) {
+                everConnected = true;
+                core.info(`pause-idle: SSH session connected (${conns} active), entering idle-aware wait`);
+                break;
+            }
+            yield sleep(pollMs);
+        }
+        if (!everConnected) {
+            core.info("pause-idle: no SSH connection during grace period, stopping breakpoint");
+            yield stopBreakpoint();
+            return;
+        }
+        let lastSeenConnectedAt = Date.now();
+        while (true) {
+            const conns = yield pollStatus(detector);
+            if (conns === null) {
+                core.info("breakpoint daemon stopped externally; exiting pause-idle");
+                return;
+            }
+            if (conns > 0) {
+                lastSeenConnectedAt = Date.now();
+            }
+            else if (Date.now() - lastSeenConnectedAt > idleMs) {
+                core.info(`pause-idle: idle for ${idleMs}ms with no connections, stopping breakpoint`);
+                yield stopBreakpoint();
+                return;
+            }
+            yield sleep(pollMs);
+        }
+    });
+}
+function stopBreakpoint() {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            yield exec.exec("breakpoint", ["resume"], { ignoreReturnCode: true, silent: true });
+        }
+        catch (err) {
+            core.debug(`Error stopping breakpoint: ${err}`);
+        }
+    });
+}
+// -------------------- Tool download --------------------
 function getDownloadURL() {
     return __awaiter(this, void 0, void 0, function* () {
         const { RUNNER_ARCH, RUNNER_OS } = process.env;

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -4110,8 +4110,8 @@ var exec = __nccwpck_require__(514);
 
 function getModeFromInput() {
     const mode = core.getInput("mode");
-    if (mode !== "pause" && mode !== "background") {
-        throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background"`);
+    if (mode !== "pause" && mode !== "background" && mode !== "pause-idle") {
+        throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background", "pause-idle"`);
     }
     return mode;
 }
@@ -4129,6 +4129,48 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 
 
 
+const STATE_CHECK_RUN_ID = "breakpoint_check_run_id";
+const STATE_CHECK_RUN_REPO = "breakpoint_check_run_repo";
+function resolveBreakpointCheckRun() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const checkRunId = core.getState(STATE_CHECK_RUN_ID);
+        const repo = core.getState(STATE_CHECK_RUN_REPO);
+        const token = core.getInput("github-token");
+        if (!checkRunId || !repo || !token) {
+            return;
+        }
+        const conclusion = core.getInput("check-run-conclusion-on-resume") || "success";
+        const body = {
+            status: "completed",
+            conclusion,
+            output: {
+                title: "SSH breakpoint resumed",
+                summary: `Breakpoint exited at ${new Date().toISOString()}.`,
+            },
+        };
+        try {
+            const res = yield fetch(`https://api.github.com/repos/${repo}/check-runs/${checkRunId}`, {
+                method: "PATCH",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    Accept: "application/vnd.github+json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "breakpoint-action",
+                },
+                body: JSON.stringify(body),
+            });
+            if (!res.ok) {
+                const text = yield res.text();
+                core.warning(`Failed to update Check Run ${checkRunId} (${res.status}): ${text.slice(0, 200)}`);
+                return;
+            }
+            core.info(`Updated Check Run ${checkRunId} -> conclusion=${conclusion}`);
+        }
+        catch (err) {
+            core.warning(`Error updating Check Run: ${err}`);
+        }
+    });
+}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -4143,6 +4185,9 @@ function run() {
             core.info("Error encountered while waiting for breakpoint to finish, it might've been stopped manually");
             core.debug(err);
         }
+        // Always try to resolve the breakpoint Check Run, regardless of mode or
+        // whether the action errored.
+        yield resolveBreakpointCheckRun();
     });
 }
 run();

--- a/lib.ts
+++ b/lib.ts
@@ -1,10 +1,11 @@
 import * as core from "@actions/core";
 
-export function getModeFromInput() {
-	const mode = core.getInput("mode");
-	if (mode !== "pause" && mode !== "background") {
-		throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background"`);
-	}
+export type Mode = "pause" | "background" | "pause-idle";
 
+export function getModeFromInput(): Mode {
+	const mode = core.getInput("mode");
+	if (mode !== "pause" && mode !== "background" && mode !== "pause-idle") {
+		throw new Error(`Invalid mode "${mode}" specified, must be one of "pause", "background", "pause-idle"`);
+	}
 	return mode;
 }

--- a/main.ts
+++ b/main.ts
@@ -7,6 +7,13 @@ import { getModeFromInput } from "./lib";
 
 const defaultBreakpointVersion = "0.0.24";
 
+// Matches the "Connect with: ssh -p <PORT> <USER>@<HOST>" line emitted by
+// the breakpoint binary once the rendezvous tunnel is established.
+const sshLineRegex = /Connect with:\s*(ssh\s+-p\s+\d+\s+\S+@\S+)/;
+
+const STATE_CHECK_RUN_ID = "breakpoint_check_run_id";
+const STATE_CHECK_RUN_REPO = "breakpoint_check_run_repo";
+
 function getBreakpointVersion(): string {
 	const override = process.env.BREAKPOINT_VERSION?.trim().replace(/^v/, "");
 	if (override) {
@@ -47,7 +54,6 @@ async function run(): Promise<void> {
 }
 
 async function installBreakpoint(): Promise<void> {
-	// Download the specific version of the tool, e.g. as a tarball.
 	const toolURL = await getDownloadURL();
 	core.info(`Downloading: ${toolURL}`);
 
@@ -57,43 +63,313 @@ async function installBreakpoint(): Promise<void> {
 		accept: "application/octet-stream",
 	});
 
-	// Extract the tarball onto the runner.
 	const pathToCLI = await tc.extractTar(pathToTarball);
-
-	// Expose the tool by adding it to the $PATH.
 	core.addPath(pathToCLI);
 }
+
+// -------------------- Check Run signalling --------------------
+
+interface CheckRunContext {
+	name: string;
+	summaryTemplate: string;
+	token: string;
+	owner: string;
+	repo: string;
+	headSha: string;
+}
+
+function readCheckRunContext(): CheckRunContext | null {
+	const name = core.getInput("check-run-name");
+	if (!name) {
+		return null;
+	}
+
+	const token = core.getInput("github-token");
+	if (!token) {
+		core.warning("check-run-name is set but no github-token provided; skipping Check Run signal.");
+		return null;
+	}
+
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!repository) {
+		core.warning("Missing GITHUB_REPOSITORY; skipping Check Run signal.");
+		return null;
+	}
+	const [owner, repo] = repository.split("/");
+
+	const headSha = resolveHeadSha();
+	if (!headSha) {
+		core.warning("Could not determine head SHA; skipping Check Run signal.");
+		return null;
+	}
+
+	return {
+		name,
+		summaryTemplate: core.getInput("check-run-summary-template") || "## SSH breakpoint open\n\n```\n{endpoint}\n```",
+		token,
+		owner,
+		repo,
+		headSha,
+	};
+}
+
+// In pull_request workflows, GITHUB_SHA is the merge commit. Check Runs need
+// the PR head SHA so they surface on the PR's Checks tab — pull it from the
+// event payload when present, fall back to GITHUB_SHA otherwise.
+function resolveHeadSha(): string | null {
+	const eventPath = process.env.GITHUB_EVENT_PATH;
+	if (eventPath) {
+		try {
+			const evt = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+			const prHead = evt?.pull_request?.head?.sha;
+			if (prHead) return prHead;
+		} catch (err) {
+			core.debug(`Failed to read event payload: ${err}`);
+		}
+	}
+	return process.env.GITHUB_SHA || null;
+}
+
+async function createBreakpointCheckRun(ctx: CheckRunContext, endpoint: string): Promise<number | null> {
+	const summary = ctx.summaryTemplate.split("{endpoint}").join(endpoint);
+	const body = {
+		name: ctx.name,
+		head_sha: ctx.headSha,
+		status: "completed",
+		conclusion: "failure",
+		output: {
+			title: "SSH breakpoint open — paused for debug",
+			summary,
+		},
+	};
+
+	try {
+		const res = await fetch(`https://api.github.com/repos/${ctx.owner}/${ctx.repo}/check-runs`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${ctx.token}`,
+				Accept: "application/vnd.github+json",
+				"Content-Type": "application/json",
+				"User-Agent": "breakpoint-action",
+			},
+			body: JSON.stringify(body),
+		});
+		if (!res.ok) {
+			const text = await res.text();
+			core.warning(`Failed to create Check Run (${res.status}): ${text.slice(0, 200)}`);
+			return null;
+		}
+		const json = (await res.json()) as { id: number };
+		core.info(`Created Check Run ${json.id} ("${ctx.name}") with conclusion=failure`);
+		return json.id;
+	} catch (err) {
+		core.warning(`Error creating Check Run: ${err}`);
+		return null;
+	}
+}
+
+// -------------------- Endpoint detection --------------------
+
+// EndpointDetector centralises the "watch breakpoint output, surface the SSH
+// endpoint" logic. The same detector is fed both by stdout listeners of
+// long-running `breakpoint wait`/`breakpoint start` calls and by the output
+// of periodic `breakpoint status` polls during `pause-idle`.
+interface EndpointDetector {
+	feed: (text: string) => Promise<void>;
+	execOpts: exec.ExecOptions;
+}
+
+function makeEndpointDetector(checkRunCtx: CheckRunContext | null): EndpointDetector {
+	let captured = "";
+	let done = false;
+
+	const feed = async (text: string): Promise<void> => {
+		if (done || !text) return;
+		captured += text;
+		const match = captured.match(sshLineRegex);
+		if (!match) return;
+
+		done = true;
+		const endpoint = match[1].trim();
+		core.setOutput("endpoint", endpoint);
+		core.notice(endpoint, { title: "SSH breakpoint endpoint" });
+		core.info(`Detected SSH endpoint: ${endpoint}`);
+
+		if (checkRunCtx) {
+			const id = await createBreakpointCheckRun(checkRunCtx, endpoint);
+			if (id !== null) {
+				core.saveState(STATE_CHECK_RUN_ID, String(id));
+				core.saveState(STATE_CHECK_RUN_REPO, `${checkRunCtx.owner}/${checkRunCtx.repo}`);
+			}
+		}
+	};
+
+	const execOpts: exec.ExecOptions = {
+		listeners: {
+			stdout: (data: Buffer) => {
+				const text = data.toString();
+				process.stdout.write(text);
+				void feed(text);
+			},
+		},
+		// We do our own writing to stdout so we don't double up.
+		silent: true,
+	};
+
+	return { feed, execOpts };
+}
+
+// -------------------- Mode dispatch --------------------
 
 async function runBreakpoint(): Promise<void> {
 	const configFile = tmpFile("config.json");
 	const config = createConfiguration();
-
 	const mode = getModeFromInput();
 
 	core.debug(`Mode: ${mode}`);
 
-	if (mode === "background") {
-		core.info("Duration input is ignored when running in background mode");
+	if (mode === "background" || mode === "pause-idle") {
+		// Duration is managed differently in these modes.
 		config.duration = "10h";
 	}
 
-	core.debug(`Configuration: ${config}`);
+	core.debug(`Configuration: ${JSON.stringify(config)}`);
+	// Write the file synchronously — the original async version had a race
+	// against the immediately-following exec.
+	fs.writeFileSync(configFile, JSON.stringify(config));
 
-	fs.writeFile(configFile, JSON.stringify(config), (err) => {
-		if (err) {
-			core.setFailed(`Failed to write config file: ${err.message}`);
-			return;
-		}
-	});
+	const checkRunCtx = readCheckRunContext();
+	const detector = makeEndpointDetector(checkRunCtx);
 
 	core.debug(new Date().toTimeString());
-	if (mode === "pause") {
-		await exec.exec(`breakpoint wait --config=${configFile}`);
-	} else {
-		await exec.exec(`breakpoint start --config=${configFile}`);
+	switch (mode) {
+		case "pause":
+			await exec.exec(`breakpoint wait --config=${configFile}`, [], detector.execOpts);
+			break;
+
+		case "background":
+			await exec.exec(`breakpoint start --config=${configFile}`, [], detector.execOpts);
+			break;
+
+		case "pause-idle":
+			await runPauseIdle(configFile, detector);
+			break;
 	}
 	core.debug(new Date().toTimeString());
 }
+
+// -------------------- pause-idle implementation --------------------
+
+function parseDurationToMs(input: string, fallbackMs: number): number {
+	const m = input.match(/^(\d+)\s*(ms|s|m|h)?$/);
+	if (!m) return fallbackMs;
+	const n = parseInt(m[1], 10);
+	const unit = m[2] || "s";
+	switch (unit) {
+		case "ms":
+			return n;
+		case "s":
+			return n * 1000;
+		case "m":
+			return n * 60 * 1000;
+		case "h":
+			return n * 60 * 60 * 1000;
+	}
+	return fallbackMs;
+}
+
+// pollStatus runs `breakpoint status`, feeds its output to the endpoint
+// detector (so we surface the SSH endpoint on the first poll where it appears
+// — `breakpoint start` itself does not print it), and returns the number of
+// currently-active SSH connections. Returns null when the daemon is no longer
+// reachable.
+async function pollStatus(detector: EndpointDetector): Promise<number | null> {
+	let output = "";
+	const exitCode = await exec.exec("breakpoint", ["status"], {
+		listeners: {
+			stdout: (data: Buffer) => {
+				output += data.toString();
+			},
+			stderr: () => {
+				/* swallow */
+			},
+		},
+		ignoreReturnCode: true,
+		silent: true,
+	});
+	if (exitCode !== 0) {
+		return null;
+	}
+	await detector.feed(output);
+	const match = output.match(/Active connections:\s*(\d+)/);
+	return match ? parseInt(match[1], 10) : 0;
+}
+
+async function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runPauseIdle(configFile: string, detector: EndpointDetector): Promise<void> {
+	// Start the daemon. `breakpoint start` returns once the rendezvous tunnel
+	// is up; the SSH endpoint is then printed by `breakpoint status` (which we
+	// poll below), not by `start` itself.
+	await exec.exec(`breakpoint start --config=${configFile}`, [], detector.execOpts);
+
+	const graceMs = parseDurationToMs(core.getInput("grace-period") || "20m", 20 * 60 * 1000);
+	const idleMs = parseDurationToMs(core.getInput("idle-timeout") || "10m", 10 * 60 * 1000);
+	const pollMs = 5000;
+
+	core.info(`pause-idle: grace=${graceMs}ms, idle-timeout=${idleMs}ms (waiting for first SSH connection)`);
+
+	const graceDeadline = Date.now() + graceMs;
+	let everConnected = false;
+	while (Date.now() < graceDeadline) {
+		const conns = await pollStatus(detector);
+		if (conns === null) {
+			core.info("breakpoint daemon is no longer reachable; exiting pause-idle");
+			return;
+		}
+		if (conns > 0) {
+			everConnected = true;
+			core.info(`pause-idle: SSH session connected (${conns} active), entering idle-aware wait`);
+			break;
+		}
+		await sleep(pollMs);
+	}
+
+	if (!everConnected) {
+		core.info("pause-idle: no SSH connection during grace period, stopping breakpoint");
+		await stopBreakpoint();
+		return;
+	}
+
+	let lastSeenConnectedAt = Date.now();
+	while (true) {
+		const conns = await pollStatus(detector);
+		if (conns === null) {
+			core.info("breakpoint daemon stopped externally; exiting pause-idle");
+			return;
+		}
+		if (conns > 0) {
+			lastSeenConnectedAt = Date.now();
+		} else if (Date.now() - lastSeenConnectedAt > idleMs) {
+			core.info(`pause-idle: idle for ${idleMs}ms with no connections, stopping breakpoint`);
+			await stopBreakpoint();
+			return;
+		}
+		await sleep(pollMs);
+	}
+}
+
+async function stopBreakpoint(): Promise<void> {
+	try {
+		await exec.exec("breakpoint", ["resume"], { ignoreReturnCode: true, silent: true });
+	} catch (err) {
+		core.debug(`Error stopping breakpoint: ${err}`);
+	}
+}
+
+// -------------------- Tool download --------------------
 
 async function getDownloadURL(): Promise<string> {
 	const { RUNNER_ARCH, RUNNER_OS } = process.env;

--- a/post.ts
+++ b/post.ts
@@ -2,6 +2,50 @@ import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import { getModeFromInput } from "./lib";
 
+const STATE_CHECK_RUN_ID = "breakpoint_check_run_id";
+const STATE_CHECK_RUN_REPO = "breakpoint_check_run_repo";
+
+async function resolveBreakpointCheckRun(): Promise<void> {
+	const checkRunId = core.getState(STATE_CHECK_RUN_ID);
+	const repo = core.getState(STATE_CHECK_RUN_REPO);
+	const token = core.getInput("github-token");
+
+	if (!checkRunId || !repo || !token) {
+		return;
+	}
+
+	const conclusion = core.getInput("check-run-conclusion-on-resume") || "success";
+	const body = {
+		status: "completed",
+		conclusion,
+		output: {
+			title: "SSH breakpoint resumed",
+			summary: `Breakpoint exited at ${new Date().toISOString()}.`,
+		},
+	};
+
+	try {
+		const res = await fetch(`https://api.github.com/repos/${repo}/check-runs/${checkRunId}`, {
+			method: "PATCH",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"Content-Type": "application/json",
+				"User-Agent": "breakpoint-action",
+			},
+			body: JSON.stringify(body),
+		});
+		if (!res.ok) {
+			const text = await res.text();
+			core.warning(`Failed to update Check Run ${checkRunId} (${res.status}): ${text.slice(0, 200)}`);
+			return;
+		}
+		core.info(`Updated Check Run ${checkRunId} -> conclusion=${conclusion}`);
+	} catch (err) {
+		core.warning(`Error updating Check Run: ${err}`);
+	}
+}
+
 async function run(): Promise<void> {
 	try {
 		const mode = getModeFromInput();
@@ -15,6 +59,10 @@ async function run(): Promise<void> {
 		core.info("Error encountered while waiting for breakpoint to finish, it might've been stopped manually");
 		core.debug(err);
 	}
+
+	// Always try to resolve the breakpoint Check Run, regardless of mode or
+	// whether the action errored.
+	await resolveBreakpointCheckRun();
 }
 
 run();


### PR DESCRIPTION
> Supersedes #15. Same author/intent; signaling channel redesigned per discussion (Check Run instead of PR comment).

## Motivation

When `breakpoint-action` is wired into an automated CI pipeline (fail-on-test with operators not necessarily watching the run live), three friction points come up:

1. **Endpoint discovery.** The SSH endpoint is printed to the step log, but GitHub buffers per-step logs until the step concludes — which for `mode: pause` is exactly when the breakpoint ends. From the outside, the endpoint is invisible while it would be useful.
2. **Fixed timeouts are wasteful or short.** A fixed `duration` either burns runner time when nobody attaches, or expires mid-investigation.
3. **No structured signal to other tooling.** External watchers (CI dashboards, AI assistants reviewing PRs) have no canonical way to know "a breakpoint is open on this PR; here's how to reach it".

## Changes

Three coherent, opt-in additions:

### 1. `endpoint` step output + `::notice::` annotation
The action now parses `breakpoint`'s stdout (both from `wait` and from periodic `status` polls in `pause-idle`) for `Connect with: ssh -p <port> <user>@<host>` and on first match:
- Sets `core.setOutput("endpoint", ...)` so following steps can use `${{ steps.bp.outputs.endpoint }}`.
- Emits `core.notice(endpoint, { title: "SSH breakpoint endpoint" })`. Check Run annotations are queryable via the REST API while the run is still in progress, so this is the closest thing to live log streaming the GitHub API offers.

### 2. `mode: pause-idle`
A new mode that pauses for `grace-period` (default 20m) waiting for the first SSH connection, then keeps the workflow paused while sessions are active, and exits after `idle-timeout` (default 10m) of zero connections. Implemented as `breakpoint start` + a polling loop on `breakpoint status`. Existing modes (`pause`, `background`) are unchanged.

### 3. Optional Check Run signaling
New inputs: `check-run-name`, `check-run-summary-template`, `check-run-conclusion-on-resume`, `github-token`.

When `check-run-name` is set, the action creates a dedicated Check Run with `conclusion: failure` and the endpoint embedded in `output.summary` (Markdown, rendered in the GitHub UI) as soon as the SSH endpoint is detected. The Check Run surfaces as a standard failed check on the PR — visible in \`gh pr checks\` and to any CI watcher without bespoke marker parsing. When the breakpoint exits, the post-step updates the Check Run to \`conclusion: success\` (or whatever the operator configured).

This replaces the original PR-comment notification from the closed #15: more standard semantics (it's a check, not chat), no PR conversation noise, no marker grepping.

Requires \`permissions: checks: write\` on the calling job.

## Risk and scope

- Implementation is additive. No existing input/output semantic changed.
- All new features are opt-in: default behaviour with no new inputs is identical to upstream.
- Synchronous config-file write inside \`runBreakpoint\` (the original async-callback version had a race against the immediately-following \`exec\`); behaviour difference is zero in practice but the failure mode disappears.
- Bundled \`dist/\` rebuilt with \`npm run build\`.
- \`prettier\`/\`eslint\` clean.

## Splitting

Happy to split into smaller PRs if preferred:
1. endpoint output + annotation
2. pause-idle mode
3. Check Run signaling