### PR TITLE
Update breakpoint to v0.0.25

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -6777,7 +6777,7 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 
 
 
-const defaultBreakpointVersion = "0.0.24";
+const defaultBreakpointVersion = "0.0.25";
 function getBreakpointVersion() {
     var _a;
     const override = (_a = process.env.BREAKPOINT_VERSION) === null || _a === void 0 ? void 0 : _a.trim().replace(/^v/, "");

--- a/main.ts
+++ b/main.ts
@@ -5,7 +5,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { getModeFromInput } from "./lib";
 
-const defaultBreakpointVersion = "0.0.24";
+const defaultBreakpointVersion = "0.0.25";
 
 function getBreakpointVersion(): string {
 	const override = process.env.BREAKPOINT_VERSION?.trim().replace(/^v/, "");


### PR DESCRIPTION
## Summary

- Update the default breakpoint binary from v0.0.24 to v0.0.25.
- Rebuild the committed action bundle.

## Validation

- `npm run build`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format-check`
